### PR TITLE
Allow returning arbitrary data from the handleAction function

### DIFF
--- a/src/handle-action.ts
+++ b/src/handle-action.ts
@@ -18,7 +18,7 @@ export default function handleAction<S, AC extends TsActionCreator<any> = any>(
 ): Reducer<S, ReturnType<AC>> {
   return produce((draft: Draft<S>, action: ReturnType<AC>) => {
     if (action.type === ac.type) {
-      re(draft, action);
+        return re(draft, action);
     }
   }, s) as any; // see https://github.com/mweststrate/immer/issues/289
 }


### PR DESCRIPTION
Useful for completely replacing the state when it makes more sense than modifying the current state. Acts as a sort of escape hatch for when more traditional reducer logic, including the use of higher-order array functions, is desired.

e.g.

```
handleAction(actions.storeFooArray, (draft, { payload }) => {
  return payload;
}),
handleAction(actions.storeUpdatedFooInArray, (draft, { payload }) => {
  return [...draft.filter(f => f.x !== payload.x), payload]
}),
```