### PR TITLE
Allow returning arbitrary data from the handleAction function

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ import { createAction, handleAction, reduceReducers } from 'redux-ts-utils';
 const increment = createAction<void>('increment');
 const decrement = createAction<void>('decrement');
 const add = createAction<number>('add');
+const override = createAction<number>('override');
 
 // Reducer
 
@@ -45,6 +46,9 @@ const reducer = reduceReducers<State>([
   handleAction(add, (state, { payload }) => {
     state.counter += payload;
   }),
+  handleAction(override, (_, { payload }) => ({
+    counter: payload,
+  })),
 ], initialState);
 
 // Store
@@ -141,6 +145,9 @@ the incoming state object and return the optimally-immutably-updated new state
 object. [`immer`] will also provide you with a mapped type (`Draft`) of your
 state with all `readonly` modifiers removed (it will also remove `Readonly`
 mapped types and convert `ReadonlyArray`s to standard arrays).
+
+If your mutation function returns a value other than `undefined`, and does not mutate the
+incoming state object, that return value will become the new state instead.
 
 ### `reduceReducers<S>(reducers: Reducer[], initialState?: S)`
 

--- a/src/example.ts
+++ b/src/example.ts
@@ -8,6 +8,7 @@ import { createAction, handleAction, reduceReducers } from '.';
 const increment = createAction<void>('increment');
 const decrement = createAction<void>('decrement');
 const add = createAction<number>('add');
+const override = createAction<number>('override');
 
 // Reducer
 
@@ -29,6 +30,9 @@ const reducer = reduceReducers<State>([
   handleAction(add, (state, { payload }) => {
     state.counter += payload;
   }),
+  handleAction(override, (_, { payload }) => ({
+    counter: payload,
+  })),
 ], initialState);
 
 // Store

--- a/src/handle-action.test.ts
+++ b/src/handle-action.test.ts
@@ -32,3 +32,35 @@ test('handles specific action with payload', () => {
   expect(newState2).toEqual({ counter: 0 });
   expect(newState2).toBe(state);
 });
+
+test('handles specific action with payload by returning value directly', () => {
+  const ac1 = createAction<{ num: number }>('foo3');
+  const state: { readonly counter: number } = { counter: 0 };
+  const re = handleAction<typeof state>(ac1, (draft, { payload }) => ({
+    counter: draft.counter + payload.num,
+  }), state);
+  const newState1 = re(state, ac1({ num: 7 }));
+  expect(newState1).toEqual({ counter: 7 });
+  expect(newState1).not.toBe(state);
+});
+
+test('handles specific action with payload and ignores directly returned value if draft is mutated', () => {
+  const ac1 = createAction<{ num: number }>('foo4');
+  const state: { readonly counter: number } = { counter: 0 };
+  const re = handleAction<typeof state>(ac1, (draft, { payload }) => {
+    draft.counter += payload.num;
+    return 'unintended return value';
+  }, state);
+  const newState1 = re(state, ac1({ num: 10 }));
+  expect(newState1).toEqual({ counter: 10 });
+  expect(newState1).not.toBe(state);
+});
+
+test('handles specific action and uses previous state if directly return value is undefined', () => {
+  const ac1 = createAction<void>('foo5');
+  const state: { readonly baz: number } = { baz: 0 };
+  const re = handleAction<typeof state>(ac1, () => undefined, state);
+  const newState1 = re(state, ac1());
+  expect(newState1).toEqual({ baz: 0 });
+  expect(newState1).toBe(state);
+});

--- a/src/handle-action.ts
+++ b/src/handle-action.ts
@@ -28,9 +28,9 @@ export default function handleAction<S, AC extends TsActionCreator<any> = any>(
 
       if (finishedDraft === state && reResult !== undefined) {
         return reResult;
-      } else {
-        return finishedDraft;
       }
+
+      return finishedDraft;
     }
     return (state || s) as any;
   };

--- a/src/handle-action.ts
+++ b/src/handle-action.ts
@@ -23,8 +23,14 @@ export default function handleAction<S, AC extends TsActionCreator<any> = any>(
   return (state: S | undefined, action: ReturnType<AC>) => {
     if (action.type === ac.type && state) {
       const draft = createDraft(state);
-      re(draft, action);
-      return finishDraft(draft);
+      const reResult = re(draft, action);
+      const finishedDraft = finishDraft(draft);
+
+      if (finishedDraft === state && reResult !== undefined) {
+        return reResult;
+      } else {
+        return finishedDraft;
+      }
     }
     return (state || s) as any;
   };


### PR DESCRIPTION
Useful for completely replacing the state when it makes more sense than modifying the current state. Acts as a sort of escape hatch for when more traditional reducer logic, including the use of higher-order array functions, is desired.

e.g.

```
handleAction(actions.storeFooArray, (draft, { payload }) => {
  return payload;
}),
handleAction(actions.storeUpdatedFooInArray, (draft, { payload }) => {
  return [...draft.filter(f => f.x !== payload.x), payload]
}),
```