### PR TITLE
fix: type-safety of action creators

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ import { createAction, handleAction, reduceReducers } from 'redux-ts-utils';
 
 // Actions
 
-const increment = createAction<void>('increment');
-const decrement = createAction<void>('decrement');
+const increment = createAction('increment');
+const decrement = createAction('decrement');
 const add = createAction<number>('add');
 const override = createAction<number>('override');
 
@@ -62,7 +62,11 @@ store.dispatch(increment());
 store.dispatch(increment());
 store.dispatch(increment());
 store.dispatch(decrement());
+// store.dispatch(decrement(1)); <-- TypeError: Expected 0 arguments, but got 1.
+
 store.dispatch(add(10));
+// store.dispatch(add()); <-- TypeError: Expected 1 arguments, but got 0.
+
 console.log('Final count!', store.getState().counter); // 12
 ```
 
@@ -104,7 +108,9 @@ properties: `type` (a `string`) and `payload` (typed as `T`).
 Typically it is best to use the simplest signature for this function:
 
 ```ts
-const myActionCreator = createAction<MyActionPayload>('MY_ACTION');
+const myVoidActionCreator = createAction('MY_VOID_ACTION');
+
+const myPayloadActionCreator = createAction<MyActionPayload>('MY_PAYLOAD_ACTION');
 ```
 
 The action creator function will be typed to take whatever you provide as a

--- a/src/create-action.ts
+++ b/src/create-action.ts
@@ -11,16 +11,32 @@ export interface TsActionCreator<P = void, A extends any[] = [P], M = void> {
   (...args: A): TsAction<P, M>;
   type: string;
 }
+interface TsIdentityPayloadActionCreator<P> {
+  (payload: P): TsAction<P, void>;
+  type: string;
+}
+interface TsVoidActionCreator {
+  (): TsAction<void, void>;
+  type: string;
+}
 
 export type PayloadCreator<P, A extends any[] = [P?]> = (...args: A) => P;
 export const identity = <T extends any[]>(...arg: T): T[0] => arg[0];
 
-// eslint-disable-next-line arrow-parens
-export default <P, A extends any[] = [P?], M = void>(
+
+function createAction(type: string): TsVoidActionCreator;
+function createAction<P>(type: string): TsIdentityPayloadActionCreator<P>;
+function createAction<P, A extends any[] = [P?], M = void>(
+  type: string,
+  pc: PayloadCreator<P, A>,
+  mc?: PayloadCreator<M, A>,
+): TsActionCreator<P, A, M>;
+
+function createAction <P, A extends any[] = [P?], M = void>(
   type: string,
   pc: PayloadCreator<P, A> = identity,
   mc?: PayloadCreator<M, A>,
-): TsActionCreator<P, A, M> => {
+): TsVoidActionCreator | TsIdentityPayloadActionCreator<P> | TsActionCreator<P, A, M> {
   // Continue with creating an action creator
   const ac = (...args: A): TsAction<P, M> => {
     const payload = pc(...args);
@@ -42,4 +58,6 @@ export default <P, A extends any[] = [P?], M = void>(
   ac.toString = () => type;
 
   return ac as TsActionCreator<P, A, M>;
-};
+}
+
+export default createAction;

--- a/src/example.ts
+++ b/src/example.ts
@@ -5,8 +5,8 @@ import { createAction, handleAction, reduceReducers } from '.';
 
 // Actions
 
-const increment = createAction<void>('increment');
-const decrement = createAction<void>('decrement');
+const increment = createAction('increment');
+const decrement = createAction('decrement');
 const add = createAction<number>('add');
 const override = createAction<number>('override');
 
@@ -46,7 +46,11 @@ store.dispatch(increment());
 store.dispatch(increment());
 store.dispatch(increment());
 store.dispatch(decrement());
+// store.dispatch(decrement(1)); <-- TypeError: Expected 0 arguments, but got 1.
+
 store.dispatch(add(10));
+// store.dispatch(add()); <-- TypeError: Expected 1 arguments, but got 0.
+
 console.log('Final count!', store.getState().counter);
 
 assert(store.getState().counter === 12);


### PR DESCRIPTION
- enforce correct number of arguments to action creators using function overloads
- update README

closes #27 and #28 - both issues are related and are fixed by the same piece of code.

I am unable to add tests for the fixed behaviour as the code would simply fail to compile.

Now that `createAction('type')` is the same as `createAction<void>('type')` instead of `createAction<{}>('type')` I updated the README to suggest the shorter form as preferable.